### PR TITLE
An update to avoid problems with status messages with undefiend enums.

### DIFF
--- a/Dorico.Net.Tests/Dorico.Net.Tests.Integration/DoricoRemoteIntegrationTests.cs
+++ b/Dorico.Net.Tests/Dorico.Net.Tests.Integration/DoricoRemoteIntegrationTests.cs
@@ -18,7 +18,7 @@ namespace Dorico.Net.Tests.Integration;
 [TestFixture]
 public class DoricoRemoteIntegrationTests
 {
-    private const string DoricoFileName = "Dorico5";
+    private const string DoricoFileName = "Dorico6";
     private const string _clientName = "Dorico.Net Integration Test";
     private readonly ServiceProvider _serviceProvider;
     private string? _sessionToken;

--- a/Dorico.Net.Tests/Dorico.Net.Tests.Unit/Json/JsonUtilsTests.cs
+++ b/Dorico.Net.Tests/Dorico.Net.Tests.Unit/Json/JsonUtilsTests.cs
@@ -1,0 +1,198 @@
+using DoricoNet.Json;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+
+namespace Dorico.Net.Tests.Unit.Json;
+
+[ExcludeFromCodeCoverage]
+[TestFixture]
+internal class JsonUtilsTests
+{
+    private static JsonElement Parse(string json) =>
+        JsonDocument.Parse(json).RootElement;
+
+    [Test]
+    public void Merge_DisjointProperties_ContainsBoth()
+    {
+        var original = """{"a": 1}""";
+        var newContent = """{"b": 2}""";
+
+        var result = Parse(JsonUtils.Merge(original, newContent));
+
+        Assert.That(result.GetProperty("a").GetInt32(), Is.EqualTo(1));
+        Assert.That(result.GetProperty("b").GetInt32(), Is.EqualTo(2));
+    }
+
+    [Test]
+    public void Merge_OverlappingProperty_NewContentWins()
+    {
+        var original = """{"a": 1, "b": 2}""";
+        var newContent = """{"b": 99}""";
+
+        var result = Parse(JsonUtils.Merge(original, newContent));
+
+        Assert.That(result.GetProperty("a").GetInt32(), Is.EqualTo(1));
+        Assert.That(result.GetProperty("b").GetInt32(), Is.EqualTo(99));
+    }
+
+    [Test]
+    public void Merge_NewContentNullForExistingProperty_OriginalValuePreserved()
+    {
+        var original = """{"a": 1, "b": 2}""";
+        var newContent = """{"b": null}""";
+
+        var result = Parse(JsonUtils.Merge(original, newContent));
+
+        Assert.That(result.GetProperty("a").GetInt32(), Is.EqualTo(1));
+        Assert.That(result.GetProperty("b").GetInt32(), Is.EqualTo(2));
+    }
+
+    [Test]
+    public void Merge_NewContentNullForUniqueProperty_NullIsWritten()
+    {
+        var original = """{"a": 1}""";
+        var newContent = """{"c": null}""";
+
+        var result = Parse(JsonUtils.Merge(original, newContent));
+
+        Assert.That(result.GetProperty("a").GetInt32(), Is.EqualTo(1));
+        Assert.That(result.GetProperty("c").ValueKind, Is.EqualTo(JsonValueKind.Null));
+    }
+
+    [Test]
+    public void Merge_BothEmpty_ReturnsEmptyObject()
+    {
+        var result = Parse(JsonUtils.Merge("{}", "{}"));
+
+        Assert.That(result.EnumerateObject().Any(), Is.False);
+    }
+
+    [Test]
+    public void Merge_OriginalEmptyNewContentHasProperties_ReturnsNewContent()
+    {
+        var original = "{}";
+        var newContent = """{"x": 10}""";
+
+        var result = Parse(JsonUtils.Merge(original, newContent));
+
+        Assert.That(result.GetProperty("x").GetInt32(), Is.EqualTo(10));
+    }
+
+    [Test]
+    public void Merge_NewContentEmpty_ReturnsOriginal()
+    {
+        var original = """{"x": 10}""";
+        var newContent = "{}";
+
+        var result = Parse(JsonUtils.Merge(original, newContent));
+
+        Assert.That(result.GetProperty("x").GetInt32(), Is.EqualTo(10));
+    }
+
+    [Test]
+    public void Merge_StringValues_MergedCorrectly()
+    {
+        var original = """{"name": "Alice"}""";
+        var newContent = """{"name": "Bob"}""";
+
+        var result = Parse(JsonUtils.Merge(original, newContent));
+
+        Assert.That(result.GetProperty("name").GetString(), Is.EqualTo("Bob"));
+    }
+
+    [Test]
+    public void Merge_NestedObjects_NewContentReplacesEntireNestedObject()
+    {
+        var original = """{"a": {"x": 1, "y": 2}}""";
+        var newContent = """{"a": {"x": 99}}""";
+
+        var result = Parse(JsonUtils.Merge(original, newContent));
+
+        var nested = result.GetProperty("a");
+        Assert.That(nested.GetProperty("x").GetInt32(), Is.EqualTo(99));
+        Assert.That(nested.TryGetProperty("y", out _), Is.False);
+    }
+
+    [Test]
+    public void Merge_ArrayValues_NewContentReplacesArray()
+    {
+        var original = """{"items": [1, 2, 3]}""";
+        var newContent = """{"items": [4, 5]}""";
+
+        var result = Parse(JsonUtils.Merge(original, newContent));
+
+        var items = result.GetProperty("items").EnumerateArray().Select(e => e.GetInt32()).ToArray();
+        Assert.That(items, Is.EqualTo(new[] { 4, 5 }));
+    }
+
+    [Test]
+    public void Merge_CamelCaseTrue_OriginalPascalCaseMatchesNewCamelCase()
+    {
+        var original = """{"MyProp": 1}""";
+        var newContent = """{"myProp": 42}""";
+
+        var result = Parse(JsonUtils.Merge(original, newContent, camelCase: true));
+
+        Assert.That(result.GetProperty("myProp").GetInt32(), Is.EqualTo(42));
+    }
+
+    [Test]
+    public void Merge_CamelCaseFalse_PascalAndCamelAreTreatedAsDistinct()
+    {
+        var original = """{"MyProp": 1}""";
+        var newContent = """{"myProp": 42}""";
+
+        var result = Parse(JsonUtils.Merge(original, newContent, camelCase: false));
+
+        Assert.That(result.GetProperty("MyProp").GetInt32(), Is.EqualTo(1));
+        Assert.That(result.GetProperty("myProp").GetInt32(), Is.EqualTo(42));
+    }
+
+    [Test]
+    public void Merge_CamelCaseTrue_NullInNewContentPreservesOriginal()
+    {
+        var original = """{"MyProp": 5}""";
+        var newContent = """{"myProp": null}""";
+
+        var result = Parse(JsonUtils.Merge(original, newContent, camelCase: true));
+
+        Assert.That(result.GetProperty("MyProp").GetInt32(), Is.EqualTo(5));
+    }
+
+    [Test]
+    public void Merge_MultipleOverlappingAndDisjoint_AllHandledCorrectly()
+    {
+        var original = """{"a": 1, "b": 2, "c": 3}""";
+        var newContent = """{"b": 20, "d": 40}""";
+
+        var result = Parse(JsonUtils.Merge(original, newContent));
+
+        Assert.That(result.GetProperty("a").GetInt32(), Is.EqualTo(1));
+        Assert.That(result.GetProperty("b").GetInt32(), Is.EqualTo(20));
+        Assert.That(result.GetProperty("c").GetInt32(), Is.EqualTo(3));
+        Assert.That(result.GetProperty("d").GetInt32(), Is.EqualTo(40));
+    }
+
+    [Test]
+    public void Merge_BooleanValues_MergedCorrectly()
+    {
+        var original = """{"active": true}""";
+        var newContent = """{"active": false}""";
+
+        var result = Parse(JsonUtils.Merge(original, newContent));
+
+        Assert.That(result.GetProperty("active").GetBoolean(), Is.False);
+    }
+
+    [Test]
+    public void Merge_AllOriginalPropertiesNulledOut_OriginalValuesPreserved()
+    {
+        var original = """{"a": 1, "b": 2}""";
+        var newContent = """{"a": null, "b": null}""";
+
+        var result = Parse(JsonUtils.Merge(original, newContent));
+
+        Assert.That(result.GetProperty("a").GetInt32(), Is.EqualTo(1));
+        Assert.That(result.GetProperty("b").GetInt32(), Is.EqualTo(2));
+    }
+}

--- a/Dorico.Net.Tests/Dorico.Net.Tests.Unit/Json/SafeEnumJsonConverterFactoryTests.cs
+++ b/Dorico.Net.Tests/Dorico.Net.Tests.Unit/Json/SafeEnumJsonConverterFactoryTests.cs
@@ -1,0 +1,302 @@
+using DoricoNet.Json;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Dorico.Net.Tests.Unit.Json;
+
+[ExcludeFromCodeCoverage]
+[TestFixture]
+internal class SafeEnumJsonConverterFactoryTests
+{
+    private JsonSerializerOptions _options = null!;
+
+    private enum Color { Red, Green, Blue }
+
+    [Flags]
+    private enum Permissions { None = 0, Read = 1, Write = 2, Execute = 4 }
+
+    private class NonNullableModel
+    {
+        public Color Color { get; set; }
+    }
+
+    private class NullableModel
+    {
+        public Color? Color { get; set; }
+    }
+
+    [SetUp]
+    public void Setup()
+    {
+        SafeEnumJsonConverterFactory.UnknownEnumStringToken = null;
+        SafeEnumJsonConverterFactory.UnknownEnumNumberToken = null;
+
+        _options = new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true,
+            Converters = { new SafeEnumJsonConverterFactory() }
+        };
+    }
+
+    // --- CanConvert ---
+
+    [Test]
+    public void CanConvert_EnumType_ReturnsTrue()
+    {
+        var factory = new SafeEnumJsonConverterFactory();
+        Assert.That(factory.CanConvert(typeof(Color)), Is.True);
+    }
+
+    [Test]
+    public void CanConvert_NullableEnumType_ReturnsTrue()
+    {
+        var factory = new SafeEnumJsonConverterFactory();
+        Assert.That(factory.CanConvert(typeof(Color?)), Is.True);
+    }
+
+    [Test]
+    public void CanConvert_NonEnumType_ReturnsFalse()
+    {
+        var factory = new SafeEnumJsonConverterFactory();
+        Assert.That(factory.CanConvert(typeof(int)), Is.False);
+    }
+
+    [Test]
+    public void CanConvert_NullType_ThrowsArgumentNullException()
+    {
+        var factory = new SafeEnumJsonConverterFactory();
+        Assert.Throws<ArgumentNullException>(() => factory.CanConvert(null!));
+    }
+
+    // --- Non-nullable string deserialization ---
+
+    [Test]
+    public void Read_StringToken_ParsesEnumValue()
+    {
+        var result = JsonSerializer.Deserialize<NonNullableModel>("{\"Color\":\"Green\"}", _options);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Color, Is.EqualTo(Color.Green));
+    }
+
+    [Test]
+    public void Read_StringToken_CaseInsensitive()
+    {
+        var result = JsonSerializer.Deserialize<NonNullableModel>("{\"Color\":\"bLuE\"}", _options);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Color, Is.EqualTo(Color.Blue));
+    }
+
+    [Test]
+    public void Read_StringToken_EmptyString_ReturnsDefault()
+    {
+        var result = JsonSerializer.Deserialize<NonNullableModel>("{\"Color\":\"\"}", _options);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Color, Is.EqualTo(default(Color)));
+    }
+
+    [Test]
+    public void Read_StringToken_Whitespace_ReturnsDefault()
+    {
+        var result = JsonSerializer.Deserialize<NonNullableModel>("{\"Color\":\"  \"}", _options);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Color, Is.EqualTo(default(Color)));
+    }
+
+    [Test]
+    public void Read_StringToken_UnknownValue_ReturnsDefault_And_InvokesCallback()
+    {
+        Type? reportedType = null;
+        string? reportedValue = null;
+        SafeEnumJsonConverterFactory.UnknownEnumStringToken = (t, v) => { reportedType = t; reportedValue = v; };
+
+        var result = JsonSerializer.Deserialize<NonNullableModel>("{\"Color\":\"Yellow\"}", _options);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Color, Is.EqualTo(default(Color)));
+        Assert.That(reportedType, Is.EqualTo(typeof(Color)));
+        Assert.That(reportedValue, Is.EqualTo("Yellow"));
+    }
+
+    // --- Non-nullable number deserialization ---
+
+    [Test]
+    public void Read_NumberToken_DefinedValue_ParsesEnumValue()
+    {
+        var result = JsonSerializer.Deserialize<NonNullableModel>("{\"Color\":2}", _options);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Color, Is.EqualTo(Color.Blue));
+    }
+
+    [Test]
+    public void Read_NumberToken_UndefinedValue_ReturnsDefault_And_InvokesCallback()
+    {
+        Type? reportedType = null;
+        int? reportedValue = null;
+        SafeEnumJsonConverterFactory.UnknownEnumNumberToken = (t, v) => { reportedType = t; reportedValue = v; };
+
+        var result = JsonSerializer.Deserialize<NonNullableModel>("{\"Color\":99}", _options);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Color, Is.EqualTo(default(Color)));
+        Assert.That(reportedType, Is.EqualTo(typeof(Color)));
+        Assert.That(reportedValue, Is.EqualTo(99));
+    }
+
+    // --- Non-nullable null token ---
+
+    [Test]
+    public void Read_NullToken_NonNullableEnum_ReturnsDefault()
+    {
+        var result = JsonSerializer.Deserialize<NonNullableModel>("{\"Color\":null}", _options);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Color, Is.EqualTo(default(Color)));
+    }
+
+    // --- Nullable enum deserialization ---
+
+    [Test]
+    public void Read_NullToken_NullableEnum_ReturnsNull()
+    {
+        var result = JsonSerializer.Deserialize<NullableModel>("{\"Color\":null}", _options);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Color, Is.Null);
+    }
+
+    [Test]
+    public void Read_StringToken_NullableEnum_ParsesValue()
+    {
+        var result = JsonSerializer.Deserialize<NullableModel>("{\"Color\":\"Blue\"}", _options);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Color, Is.EqualTo(Color.Blue));
+    }
+
+    [Test]
+    public void Read_StringToken_NullableEnum_UnknownValue_ReturnsDefault()
+    {
+        var result = JsonSerializer.Deserialize<NullableModel>("{\"Color\":\"Yellow\"}", _options);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Color, Is.EqualTo(default(Color)));
+    }
+
+    [Test]
+    public void Read_NumberToken_NullableEnum_DefinedValue_ParsesValue()
+    {
+        var result = JsonSerializer.Deserialize<NullableModel>("{\"Color\":1}", _options);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Color, Is.EqualTo(Color.Green));
+    }
+
+    // --- Serialization (non-nullable) ---
+
+    [Test]
+    public void Write_NonNullableEnum_WritesString()
+    {
+        var json = JsonSerializer.Serialize(new NonNullableModel { Color = Color.Green }, _options);
+
+        Assert.That(json, Does.Contain("\"Green\""));
+    }
+
+    // --- Serialization (nullable) ---
+
+    [Test]
+    public void Write_NullableEnum_WithValue_WritesString()
+    {
+        var json = JsonSerializer.Serialize(new NullableModel { Color = Color.Blue }, _options);
+
+        Assert.That(json, Does.Contain("\"Blue\""));
+    }
+
+    [Test]
+    public void Write_NullableEnum_Null_WritesNull()
+    {
+        var json = JsonSerializer.Serialize(new NullableModel { Color = null }, _options);
+
+        Assert.That(json, Does.Contain("null"));
+    }
+
+    // --- Unsupported token types ---
+
+    [Test]
+    public void Read_BooleanToken_ReturnsDefault()
+    {
+        var result = JsonSerializer.Deserialize<NonNullableModel>("{\"Color\":true}", _options);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Color, Is.EqualTo(default(Color)));
+    }
+
+    [Test]
+    public void Read_ObjectToken_ReturnsDefault()
+    {
+        var result = JsonSerializer.Deserialize<NonNullableModel>("{\"Color\":{}}", _options);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Color, Is.EqualTo(default(Color)));
+    }
+
+    [Test]
+    public void Read_ArrayToken_ReturnsDefault()
+    {
+        var result = JsonSerializer.Deserialize<NonNullableModel>("{\"Color\":[]}", _options);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Color, Is.EqualTo(default(Color)));
+    }
+
+    // --- Callbacks not set (no-op path) ---
+
+    [Test]
+    public void Read_UnknownString_NoCallback_DoesNotThrow()
+    {
+        SafeEnumJsonConverterFactory.UnknownEnumStringToken = null;
+
+        var result = JsonSerializer.Deserialize<NonNullableModel>("{\"Color\":\"Yellow\"}", _options);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Color, Is.EqualTo(default(Color)));
+    }
+
+    [Test]
+    public void Read_UndefinedNumber_NoCallback_DoesNotThrow()
+    {
+        SafeEnumJsonConverterFactory.UnknownEnumNumberToken = null;
+
+        var result = JsonSerializer.Deserialize<NonNullableModel>("{\"Color\":99}", _options);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.Color, Is.EqualTo(default(Color)));
+    }
+
+    // --- CreateConverter ---
+
+    [Test]
+    public void CreateConverter_NonNullableEnum_ReturnsConverter()
+    {
+        var factory = new SafeEnumJsonConverterFactory();
+        var converter = factory.CreateConverter(typeof(Color), _options);
+
+        Assert.That(converter, Is.Not.Null);
+        Assert.That(converter, Is.InstanceOf<JsonConverter<Color>>());
+    }
+
+    [Test]
+    public void CreateConverter_NullableEnum_ReturnsNullableConverter()
+    {
+        var factory = new SafeEnumJsonConverterFactory();
+        var converter = factory.CreateConverter(typeof(Color?), _options);
+
+        Assert.That(converter, Is.Not.Null);
+        Assert.That(converter, Is.InstanceOf<JsonConverter<Color?>>());
+    }
+}

--- a/Dorico.Net/Comms/ClientWebSocketWrapper.cs
+++ b/Dorico.Net/Comms/ClientWebSocketWrapper.cs
@@ -146,7 +146,7 @@ public partial class ClientWebSocketWrapper(ILogger logger) : IClientWebSocketWr
         AssertSocketOpen();
 
         var response = await _clientWebSocket!.ReceiveAsync(buffer, cancellationToken).ConfigureAwait(false);
-        LogReceived(System.Text.Encoding.UTF8.GetString(buffer));
+        LogReceived(Encoding.UTF8.GetString(buffer.Array, buffer.Offset, response.Count));
 
         if (response.MessageType == WebSocketMessageType.Close)
         {

--- a/Dorico.Net/Comms/DoricoCommsContext.cs
+++ b/Dorico.Net/Comms/DoricoCommsContext.cs
@@ -218,7 +218,6 @@ public partial class DoricoCommsContext(
 
         _responseQueue.Enqueue(requestInfo);
 
-#pragma warning disable CA1031 // Do not catch general exception types
         try
         {
             await socket.SendAsync(sendBuffer, WebSocketMessageType.Text, true, cancellationToken)
@@ -261,7 +260,6 @@ public partial class DoricoCommsContext(
         {
             resetEvent.Dispose();
         }
-#pragma warning restore CA1031 // Do not catch general exception types
 
         return request.Response ?? request.ErrorResponse;
     }
@@ -368,9 +366,9 @@ public partial class DoricoCommsContext(
         try
         {        
             responseObj ??= (DoricoResponseBase?)JsonSerializer.Deserialize(
-            content,
-            responseType,
-            _jsonSerializationOptions);
+                content,
+                responseType,
+                _jsonSerializationOptions);
 		}
 		catch
 		{

--- a/Dorico.Net/GlobalSuppressions.cs
+++ b/Dorico.Net/GlobalSuppressions.cs
@@ -1,0 +1,8 @@
+﻿// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("Design", "CA1031:Do not catch general exception types")]

--- a/Dorico.Net/Json/SafeEnumJsonConverterFactory.cs
+++ b/Dorico.Net/Json/SafeEnumJsonConverterFactory.cs
@@ -29,7 +29,7 @@ public sealed class SafeEnumJsonConverterFactory : JsonConverterFactory
 	/// <remarks>
 	/// The first argument is the enum <see cref="Type"/>; the second is the raw string token value (may be <c>null</c>).
 	/// </remarks>
-	public static Action<Type, string?>? UnknownEnumStringToken;
+	public static Action<Type, string?>? UnknownEnumStringToken { get; set; }
 
 	/// <summary>
 	/// Optional callback invoked when an enum value is provided as a number token but is not a defined enum value.
@@ -38,14 +38,14 @@ public sealed class SafeEnumJsonConverterFactory : JsonConverterFactory
 	/// The first argument is the enum <see cref="Type"/>; the second is the raw numeric value if it fits in an <see cref="int"/>,
 	/// otherwise <c>null</c>.
 	/// </remarks>
-	public static Action<Type, int?>? UnknownEnumNumberToken;
+	public static Action<Type, int?>? UnknownEnumNumberToken { get; set; }
 
-	/// <summary>
-	/// Determines whether this factory can create a converter for <paramref name="typeToConvert"/>.
-	/// </summary>
-	/// <param name="typeToConvert">The type to be converted.</param>
-	/// <returns><c>true</c> if the type is an enum or a nullable enum; otherwise <c>false</c>.</returns>
-	public override bool CanConvert(Type typeToConvert)
+    /// <summary>
+    /// Determines whether this factory can create a converter for <paramref name="typeToConvert"/>.
+    /// </summary>
+    /// <param name="typeToConvert">The type to be converted.</param>
+    /// <returns><c>true</c> if the type is an enum or a nullable enum; otherwise <c>false</c>.</returns>
+    public override bool CanConvert(Type typeToConvert)
 	{
 		ArgumentNullException.ThrowIfNull(typeToConvert);
 		return (Nullable.GetUnderlyingType(typeToConvert) ?? typeToConvert).IsEnum;

--- a/Dorico.Net/Json/SafeEnumJsonConverterFactory.cs
+++ b/Dorico.Net/Json/SafeEnumJsonConverterFactory.cs
@@ -1,0 +1,192 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace DoricoNet.Json;
+
+/// <summary>
+/// A <see cref="JsonConverterFactory"/> that provides resilient enum deserialization for <see cref="System.Text.Json"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This factory produces converters for any enum type (including nullable enums). During deserialization it:
+/// </para>
+/// <list type="bullet">
+/// <item><description>Accepts string tokens and parses them case-insensitively.</description></item>
+/// <item><description>Accepts numeric tokens only when the numeric value maps to a defined enum member.</description></item>
+/// <item><description>Returns <c>default</c> for unknown/invalid values instead of throwing.</description></item>
+/// <item><description>For nullable enums, JSON <c>null</c> is preserved as <c>null</c>.</description></item>
+/// </list>
+/// <para>
+/// Optional callbacks can be assigned via <see cref="UnknownEnumStringToken"/> and <see cref="UnknownEnumNumberToken"/>
+/// to observe unknown values without failing deserialization.
+/// </para>
+/// </remarks>
+public sealed class SafeEnumJsonConverterFactory : JsonConverterFactory
+{
+	/// <summary>
+	/// Optional callback invoked when an enum value is provided as a string token but cannot be parsed.
+	/// </summary>
+	/// <remarks>
+	/// The first argument is the enum <see cref="Type"/>; the second is the raw string token value (may be <c>null</c>).
+	/// </remarks>
+	public static Action<Type, string?>? UnknownEnumStringToken;
+
+	/// <summary>
+	/// Optional callback invoked when an enum value is provided as a number token but is not a defined enum value.
+	/// </summary>
+	/// <remarks>
+	/// The first argument is the enum <see cref="Type"/>; the second is the raw numeric value if it fits in an <see cref="int"/>,
+	/// otherwise <c>null</c>.
+	/// </remarks>
+	public static Action<Type, int?>? UnknownEnumNumberToken;
+
+	/// <summary>
+	/// Determines whether this factory can create a converter for <paramref name="typeToConvert"/>.
+	/// </summary>
+	/// <param name="typeToConvert">The type to be converted.</param>
+	/// <returns><c>true</c> if the type is an enum or a nullable enum; otherwise <c>false</c>.</returns>
+	public override bool CanConvert(Type typeToConvert)
+	{
+		ArgumentNullException.ThrowIfNull(typeToConvert);
+		return (Nullable.GetUnderlyingType(typeToConvert) ?? typeToConvert).IsEnum;
+	}
+
+	/// <summary>
+	/// Creates a converter for the specified enum (or nullable enum) type.
+	/// </summary>
+	/// <param name="typeToConvert">The enum type to create a converter for.</param>
+	/// <param name="options">Serializer options (not used by this implementation).</param>
+	/// <returns>A converter instance for the requested type.</returns>
+	public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+	{
+		var enumType = Nullable.GetUnderlyingType(typeToConvert) ?? typeToConvert;
+
+		var converterType = typeof(SafeEnumJsonConverter<>).MakeGenericType(enumType);
+		var converter = (JsonConverter)Activator.CreateInstance(converterType)!;
+
+		if (Nullable.GetUnderlyingType(typeToConvert) is not null)
+		{
+			var wrapperType = typeof(NullableSafeEnumJsonConverter<>).MakeGenericType(enumType);
+			return (JsonConverter)Activator.CreateInstance(wrapperType, converter)!;
+		}
+
+		return converter;
+	}
+
+	/// <summary>
+	/// A robust enum converter that tolerates unexpected JSON values.
+	/// </summary>
+	/// <typeparam name="TEnum">The enum type.</typeparam>
+	/// <remarks>
+	/// <para>
+	/// Deserialization behavior:
+	/// </para>
+	/// <list type="bullet">
+	/// <item><description>String tokens are parsed using <see cref="Enum.TryParse{TEnum}(string?, bool, out TEnum)"/> (case-insensitive).</description></item>
+	/// <item><description>Number tokens are accepted only if they fit in an <see cref="int"/> and are defined by the enum.</description></item>
+	/// <item><description>Unknown/invalid values return <c>default</c> and invoke the appropriate logging hook.</description></item>
+	/// <item><description>Unsupported token kinds are skipped best-effort and return <c>default</c>.</description></item>
+	/// </list>
+	/// <para>
+	/// Serialization writes enums as string values via <see cref="Enum.ToString()"/>.
+	/// </para>
+	/// </remarks>
+	private sealed class SafeEnumJsonConverter<TEnum> : JsonConverter<TEnum> where TEnum : struct, Enum
+	{
+		/// <summary>
+		/// Reads and converts the JSON to <typeparamref name="TEnum"/>.
+		/// </summary>
+		/// <param name="reader">The reader.</param>
+		/// <param name="typeToConvert">The type to convert.</param>
+		/// <param name="options">Serializer options.</param>
+		/// <returns>
+		/// The parsed enum value; or <c>default</c> when the JSON token is unknown/invalid for the enum.
+		/// </returns>
+		public override TEnum Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.String)
+			{
+				var s = reader.GetString();
+				if (string.IsNullOrWhiteSpace(s)) return default;
+
+				if (Enum.TryParse<TEnum>(s, ignoreCase: true, out var parsed))
+					return parsed;
+
+				UnknownEnumStringToken?.Invoke(typeof(TEnum), s);
+				return default;
+			}
+
+			if (reader.TokenType == JsonTokenType.Number)
+			{
+				if (reader.TryGetInt32(out var i) && Enum.IsDefined(typeof(TEnum), i))
+					return (TEnum)Enum.ToObject(typeof(TEnum), i);
+
+				int? n = reader.TryGetInt32(out var v) ? v : null;
+				UnknownEnumNumberToken?.Invoke(typeof(TEnum), n);
+				return default;
+			}
+
+			if (reader.TokenType == JsonTokenType.Null)
+				return default;
+
+			try { reader.Skip(); } catch { }
+			return default;
+		}
+
+		/// <summary>
+		/// Writes the enum value as a JSON string.
+		/// </summary>
+		/// <param name="writer">The writer.</param>
+		/// <param name="value">The enum value.</param>
+		/// <param name="options">Serializer options.</param>
+		public override void Write(Utf8JsonWriter writer, TEnum value, JsonSerializerOptions options)
+			=> writer.WriteStringValue(value.ToString());
+	}
+
+	/// <summary>
+	/// Wraps a non-nullable <see cref="SafeEnumJsonConverter{TEnum}"/> to support nullable enums (<typeparamref name="TEnum"/>?).
+	/// </summary>
+	/// <typeparam name="TEnum">The underlying enum type.</typeparam>
+	/// <remarks>
+	/// This converter preserves JSON <c>null</c> as <c>null</c>. For non-null tokens, it delegates to the inner
+	/// <see cref="JsonConverter{T}"/> for <typeparamref name="TEnum"/>.
+	/// </remarks>
+	private sealed class NullableSafeEnumJsonConverter<TEnum> : JsonConverter<TEnum?> where TEnum : struct, Enum
+	{
+		private readonly JsonConverter inner;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="NullableSafeEnumJsonConverter{TEnum}"/> class.
+		/// </summary>
+		/// <param name="inner">The inner converter for the non-nullable enum type.</param>
+		public NullableSafeEnumJsonConverter(JsonConverter inner) => this.inner = inner;
+
+		/// <summary>
+		/// Reads and converts the JSON to a nullable enum.
+		/// </summary>
+		/// <param name="reader">The reader.</param>
+		/// <param name="typeToConvert">The target type.</param>
+		/// <param name="options">Serializer options.</param>
+		/// <returns>
+		/// <c>null</c> when the JSON token is <c>null</c>; otherwise the value produced by the inner enum converter
+		/// (which may be <c>default</c> for unknown/invalid values).
+		/// </returns>
+		public override TEnum? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+		{
+			if (reader.TokenType == JsonTokenType.Null) return null;
+			return ((JsonConverter<TEnum>)inner).Read(ref reader, typeof(TEnum), options);
+		}
+
+		/// <summary>
+		/// Writes a nullable enum as a JSON string, or <c>null</c> when the value is <c>null</c>.
+		/// </summary>
+		/// <param name="writer">The writer.</param>
+		/// <param name="value">The enum value.</param>
+		/// <param name="options">Serializer options.</param>
+		public override void Write(Utf8JsonWriter writer, TEnum? value, JsonSerializerOptions options)
+		{
+			if (value is null) { writer.WriteNullValue(); return; }
+			((JsonConverter<TEnum>)inner).Write(writer, value.Value, options);
+		}
+	}
+}


### PR DESCRIPTION
If a status message was received with data that was not defined for an enum property, an unhandled exception was thrown when the message was deserialized, causing the receive loop to terminate. 

This update adds a deserializer that handles such a situation without throwing an exception.